### PR TITLE
Add FastAPI CRM service with tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+*.db
+pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# test-codex
-codex測試使用
+# Simple CRM 系統
+
+本專案實作一個以 FastAPI 打造的簡易客戶關係管理（CRM）服務，提供客戶資料與互動紀錄的 CRUD API，方便中小型團隊快速建置客戶資料管理系統。
+
+## 功能特色
+
+- 客戶資料新增、查詢、修改與刪除
+- 可依姓名、Email、電話或公司進行模糊搜尋
+- 透過狀態與公司欄位進行篩選與排序
+- 客戶互動紀錄管理（新增、查詢與總覽）
+- SQLite 持久化儲存，測試時可自訂資料庫路徑
+
+## 環境需求
+
+- Python 3.9+
+- pip 套件管理工具
+
+## 安裝步驟
+
+```bash
+pip install -r requirements.txt
+```
+
+## 執行 API 服務
+
+```bash
+uvicorn app.main:app --reload
+```
+
+啟動後即可透過 `http://127.0.0.1:8000/docs` 進入自動產生的互動式 API 文件。
+
+## 主要 API 一覽
+
+| 方法 | 路徑 | 說明 |
+| ---- | ---- | ---- |
+| GET | `/health` | 服務健康檢查 |
+| POST | `/customers` | 建立客戶資料 |
+| GET | `/customers` | 取得客戶清單（支援搜尋、篩選、排序） |
+| GET | `/customers/{customer_id}` | 取得特定客戶資料 |
+| PUT | `/customers/{customer_id}` | 更新客戶資料 |
+| DELETE | `/customers/{customer_id}` | 刪除客戶 |
+| GET | `/customers/{customer_id}/interactions` | 查詢客戶互動紀錄 |
+| POST | `/customers/{customer_id}/interactions` | 新增客戶互動紀錄 |
+| GET | `/interactions` | 瀏覽全部互動紀錄 |
+
+## 執行測試
+
+```bash
+pytest
+```
+
+測試會自動使用臨時 SQLite 資料庫，以確保環境乾淨且可重複執行。

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,0 +1,186 @@
+"""Database CRUD helpers for the CRM application."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from sqlite3 import Connection, IntegrityError
+
+from . import schemas
+
+
+ALLOWED_SORT_COLUMNS = {"name", "email", "company", "status", "created_at", "updated_at"}
+
+
+def _row_to_customer(row) -> schemas.Customer:
+    return schemas.Customer(**dict(row))
+
+
+def _row_to_interaction(row) -> schemas.Interaction:
+    return schemas.Interaction(**dict(row))
+
+
+def create_customer(connection: Connection, payload: schemas.CustomerCreate) -> schemas.Customer:
+    timestamp = schemas.current_timestamp()
+    data = payload.model_dump()
+    if not data.get("status"):
+        data["status"] = "active"
+
+    try:
+        cursor = connection.execute(
+            """
+            INSERT INTO customers (name, email, phone, company, status, notes, created_at, updated_at)
+            VALUES (:name, :email, :phone, :company, :status, :notes, :created_at, :updated_at)
+            """,
+            {
+                **data,
+                "created_at": timestamp,
+                "updated_at": timestamp,
+            },
+        )
+    except IntegrityError as exc:  # pragma: no cover - exercised via API layer
+        raise ValueError("A customer with this email already exists") from exc
+
+    connection.commit()
+    customer_id = cursor.lastrowid
+    return get_customer(connection, customer_id)
+
+
+def list_customers(
+    connection: Connection,
+    *,
+    search: Optional[str] = None,
+    status: Optional[str] = None,
+    company: Optional[str] = None,
+    limit: int = 20,
+    offset: int = 0,
+    sort_by: str = "created_at",
+    sort_order: str = "desc",
+) -> List[schemas.Customer]:
+    limit = max(1, min(limit, 100))
+    offset = max(0, offset)
+    sort_column = sort_by if sort_by in ALLOWED_SORT_COLUMNS else "created_at"
+    order = "ASC" if sort_order.lower() == "asc" else "DESC"
+
+    query = ["SELECT * FROM customers"]
+    parameters: List[object] = []
+    filters = []
+
+    if search:
+        like = f"%{search.lower()}%"
+        filters.append(
+            "(LOWER(name) LIKE ? OR LOWER(email) LIKE ? OR LOWER(phone) LIKE ? OR LOWER(company) LIKE ?)"
+        )
+        parameters.extend([like, like, like, like])
+
+    if status:
+        filters.append("LOWER(status) = ?")
+        parameters.append(status.lower())
+
+    if company:
+        filters.append("LOWER(company) = ?")
+        parameters.append(company.lower())
+
+    if filters:
+        query.append("WHERE " + " AND ".join(filters))
+
+    query.append(f"ORDER BY {sort_column} {order}")
+    query.append("LIMIT ? OFFSET ?")
+    parameters.extend([limit, offset])
+
+    cursor = connection.execute(" ".join(query), parameters)
+    rows = cursor.fetchall()
+    return [_row_to_customer(row) for row in rows]
+
+
+def get_customer(connection: Connection, customer_id: int) -> Optional[schemas.Customer]:
+    cursor = connection.execute(
+        "SELECT * FROM customers WHERE id = ?",
+        (customer_id,),
+    )
+    row = cursor.fetchone()
+    return _row_to_customer(row) if row else None
+
+
+def update_customer(
+    connection: Connection,
+    customer_id: int,
+    payload: schemas.CustomerUpdate,
+) -> Optional[schemas.Customer]:
+    existing = get_customer(connection, customer_id)
+    if not existing:
+        return None
+
+    updates = payload.model_dump(exclude_unset=True)
+    if not updates:
+        return existing
+
+    updates["updated_at"] = schemas.current_timestamp()
+    set_clause = ", ".join(f"{column} = :{column}" for column in updates.keys())
+
+    try:
+        connection.execute(
+            f"UPDATE customers SET {set_clause} WHERE id = :id",
+            {**updates, "id": customer_id},
+        )
+    except IntegrityError as exc:  # pragma: no cover - exercised via API layer
+        raise ValueError("A customer with this email already exists") from exc
+
+    connection.commit()
+    return get_customer(connection, customer_id)
+
+
+def delete_customer(connection: Connection, customer_id: int) -> bool:
+    cursor = connection.execute("DELETE FROM customers WHERE id = ?", (customer_id,))
+    connection.commit()
+    return cursor.rowcount > 0
+
+
+def create_interaction(
+    connection: Connection,
+    customer_id: int,
+    payload: schemas.InteractionCreate,
+) -> Optional[schemas.Interaction]:
+    if not get_customer(connection, customer_id):
+        return None
+
+    data = payload.model_dump()
+    timestamp = schemas.current_timestamp()
+    occurred_at = data.get("occurred_at") or timestamp
+
+    cursor = connection.execute(
+        """
+        INSERT INTO interactions (customer_id, interaction_type, subject, notes, occurred_at, created_at)
+        VALUES (:customer_id, :interaction_type, :subject, :notes, :occurred_at, :created_at)
+        """,
+        {
+            **data,
+            "customer_id": customer_id,
+            "occurred_at": occurred_at,
+            "created_at": timestamp,
+        },
+    )
+    connection.commit()
+    interaction_id = cursor.lastrowid
+    return get_interaction(connection, interaction_id)
+
+
+def get_interaction(connection: Connection, interaction_id: int) -> Optional[schemas.Interaction]:
+    cursor = connection.execute("SELECT * FROM interactions WHERE id = ?", (interaction_id,))
+    row = cursor.fetchone()
+    return _row_to_interaction(row) if row else None
+
+
+def list_interactions(
+    connection: Connection,
+    customer_id: Optional[int] = None,
+) -> List[schemas.Interaction]:
+    if customer_id is not None:
+        cursor = connection.execute(
+            "SELECT * FROM interactions WHERE customer_id = ? ORDER BY occurred_at DESC",
+            (customer_id,),
+        )
+    else:
+        cursor = connection.execute("SELECT * FROM interactions ORDER BY occurred_at DESC")
+
+    rows = cursor.fetchall()
+    return [_row_to_interaction(row) for row in rows]

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,80 @@
+"""Database utilities for the CRM application."""
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from typing import Generator
+
+
+DEFAULT_DB_NAME = "crm.db"
+
+
+def get_database_path() -> Path:
+    """Return the path to the SQLite database file.
+
+    The location can be configured with the ``CRM_DB_PATH`` environment
+    variable. Relative paths are resolved from the current working directory.
+    """
+
+    path = os.getenv("CRM_DB_PATH", DEFAULT_DB_NAME)
+    return Path(path)
+
+
+def init_db() -> None:
+    """Initialise the database if it does not exist."""
+
+    db_path = get_database_path()
+    if db_path != Path(":memory:"):
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS customers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                email TEXT UNIQUE NOT NULL,
+                phone TEXT,
+                company TEXT,
+                status TEXT,
+                notes TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS interactions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                customer_id INTEGER NOT NULL,
+                interaction_type TEXT NOT NULL,
+                subject TEXT,
+                notes TEXT,
+                occurred_at TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE
+            )
+            """
+        )
+        connection.commit()
+
+
+def get_connection() -> sqlite3.Connection:
+    """Create a new SQLite connection using the configured database path."""
+
+    db_path = get_database_path()
+    connection = sqlite3.connect(db_path, check_same_thread=False)
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def get_db() -> Generator[sqlite3.Connection, None, None]:
+    """Dependency that yields a database connection for FastAPI routes."""
+
+    connection = get_connection()
+    try:
+        yield connection
+    finally:
+        connection.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,128 @@
+"""FastAPI application exposing CRM endpoints."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Query, Response, status
+from fastapi.middleware.cors import CORSMiddleware
+
+from . import crud, schemas
+from .database import get_db, init_db
+
+app = FastAPI(
+    title="Simple CRM API",
+    description="一個簡易的客戶關係管理（CRM）系統，提供客戶與互動紀錄的基本CRUD功能。",
+    version="1.0.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.on_event("startup")
+def startup() -> None:
+    init_db()
+
+
+@app.get("/health", response_model=schemas.HealthResponse)
+def healthcheck() -> schemas.HealthResponse:
+    return schemas.HealthResponse(status="ok")
+
+
+@app.post("/customers", response_model=schemas.Customer, status_code=status.HTTP_201_CREATED)
+def create_customer(
+    payload: schemas.CustomerCreate,
+    connection=Depends(get_db),
+) -> schemas.Customer:
+    try:
+        customer = crud.create_customer(connection, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return customer
+
+
+@app.get("/customers", response_model=List[schemas.Customer])
+def list_customers(
+    search: Optional[str] = Query(default=None, description="依姓名、Email、電話或公司模糊查詢"),
+    status_filter: Optional[str] = Query(default=None, alias="status", description="依客戶狀態篩選"),
+    company: Optional[str] = Query(default=None, description="依公司名稱篩選"),
+    limit: int = Query(default=20, ge=1, le=100, description="單頁筆數，最多100筆"),
+    offset: int = Query(default=0, ge=0, description="起始索引"),
+    sort_by: str = Query(default="created_at", description="排序欄位"),
+    sort_order: str = Query(default="desc", description="排序方向（asc/desc）"),
+    connection=Depends(get_db),
+) -> List[schemas.Customer]:
+    return crud.list_customers(
+        connection,
+        search=search,
+        status=status_filter,
+        company=company,
+        limit=limit,
+        offset=offset,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
+
+
+@app.get("/customers/{customer_id}", response_model=schemas.Customer)
+def get_customer(customer_id: int, connection=Depends(get_db)) -> schemas.Customer:
+    customer = crud.get_customer(connection, customer_id)
+    if not customer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Customer not found")
+    return customer
+
+
+@app.put("/customers/{customer_id}", response_model=schemas.Customer)
+def update_customer(
+    customer_id: int,
+    payload: schemas.CustomerUpdate,
+    connection=Depends(get_db),
+) -> schemas.Customer:
+    try:
+        customer = crud.update_customer(connection, customer_id, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    if not customer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Customer not found")
+    return customer
+
+
+@app.delete("/customers/{customer_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_customer(customer_id: int, connection=Depends(get_db)) -> Response:
+    deleted = crud.delete_customer(connection, customer_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Customer not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.get("/customers/{customer_id}/interactions", response_model=List[schemas.Interaction])
+def list_customer_interactions(customer_id: int, connection=Depends(get_db)) -> List[schemas.Interaction]:
+    if not crud.get_customer(connection, customer_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Customer not found")
+    return crud.list_interactions(connection, customer_id=customer_id)
+
+
+@app.post(
+    "/customers/{customer_id}/interactions",
+    response_model=schemas.Interaction,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_customer_interaction(
+    customer_id: int,
+    payload: schemas.InteractionCreate,
+    connection=Depends(get_db),
+) -> schemas.Interaction:
+    interaction = crud.create_interaction(connection, customer_id, payload)
+    if not interaction:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Customer not found")
+    return interaction
+
+
+@app.get("/interactions", response_model=List[schemas.Interaction])
+def list_interactions(connection=Depends(get_db)) -> List[schemas.Interaction]:
+    return crud.list_interactions(connection)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,74 @@
+"""Pydantic schemas for request and response validation."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+
+def current_timestamp() -> str:
+    """Return the current UTC timestamp in ISO 8601 format."""
+
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+class HealthResponse(BaseModel):
+    status: str
+
+
+class CustomerBase(BaseModel):
+    phone: Optional[str] = Field(default=None, max_length=50)
+    company: Optional[str] = Field(default=None, max_length=200)
+    status: Optional[str] = Field(default=None, max_length=50)
+    notes: Optional[str] = Field(default=None, max_length=1000)
+
+
+class CustomerCreate(CustomerBase):
+    name: str = Field(..., min_length=1, max_length=200)
+    email: EmailStr
+    status: Optional[str] = Field(default="active", max_length=50)
+
+
+class CustomerUpdate(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=200)
+    email: Optional[EmailStr] = None
+    phone: Optional[str] = Field(default=None, max_length=50)
+    company: Optional[str] = Field(default=None, max_length=200)
+    status: Optional[str] = Field(default=None, max_length=50)
+    notes: Optional[str] = Field(default=None, max_length=1000)
+
+
+class Customer(CustomerBase):
+    id: int
+    name: str
+    email: EmailStr
+    status: Optional[str]
+    created_at: str
+    updated_at: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class InteractionBase(BaseModel):
+    interaction_type: str = Field(..., min_length=1, max_length=100)
+    subject: Optional[str] = Field(default=None, max_length=200)
+    notes: Optional[str] = Field(default=None, max_length=2000)
+    occurred_at: Optional[str] = None
+
+
+class InteractionCreate(InteractionBase):
+    pass
+
+
+class Interaction(InteractionBase):
+    id: int
+    customer_id: int
+    occurred_at: str
+    created_at: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CustomerWithInteractions(Customer):
+    interactions: List[Interaction] = Field(default_factory=list)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn==0.29.0
+pytest==8.1.1
+httpx==0.27.2
+email-validator==2.2.0

--- a/tests/test_crm_api.py
+++ b/tests/test_crm_api.py
@@ -1,0 +1,134 @@
+import os
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+@pytest.fixture(scope="module")
+def client():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.environ["CRM_DB_PATH"] = os.path.join(tmpdir, "test.db")
+        from app.main import app
+
+        with TestClient(app) as test_client:
+            yield test_client
+
+
+def _unique_email() -> str:
+    return f"user-{uuid.uuid4().hex}@example.com"
+
+
+def _create_customer(client: TestClient, **overrides):
+    payload = {
+        "name": overrides.get("name", "Test User"),
+        "email": overrides.get("email", _unique_email()),
+        "phone": overrides.get("phone", "0900-000-000"),
+        "company": overrides.get("company", "Example Corp"),
+        "status": overrides.get("status", "active"),
+        "notes": overrides.get("notes", "This is a test entry."),
+    }
+    response = client.post("/customers", json=payload)
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def test_healthcheck(client: TestClient):
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_create_and_get_customer(client: TestClient):
+    created = _create_customer(client, name="Alice", company="Wonderland", status="prospect")
+    customer_id = created["id"]
+
+    response = client.get(f"/customers/{customer_id}")
+    assert response.status_code == 200
+    fetched = response.json()
+
+    assert fetched["name"] == "Alice"
+    assert fetched["company"] == "Wonderland"
+    assert fetched["status"] == "prospect"
+
+
+def test_list_customers_filters(client: TestClient):
+    _create_customer(client, name="Alice Johnson", status="prospect", company="Acme")
+    _create_customer(client, name="Bob Smith", status="customer", company="Beta")
+
+    response = client.get("/customers", params={"search": "alice"})
+    assert response.status_code == 200
+    names = [item["name"].lower() for item in response.json()]
+    assert any("alice" in name for name in names)
+
+    response = client.get("/customers", params={"status": "prospect"})
+    assert response.status_code == 200
+    statuses = {item["status"] for item in response.json()}
+    assert statuses == {"prospect"}
+
+    response = client.get("/customers", params={"company": "Beta"})
+    assert response.status_code == 200
+    companies = {item["company"] for item in response.json()}
+    assert companies == {"Beta"}
+
+    response = client.get("/customers", params={"limit": 1})
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+def test_update_customer(client: TestClient):
+    customer = _create_customer(client, name="Charlie", status="lead")
+    customer_id = customer["id"]
+
+    response = client.put(
+        f"/customers/{customer_id}",
+        json={"phone": "022-123456", "status": "customer"},
+    )
+    assert response.status_code == 200
+    updated = response.json()
+    assert updated["phone"] == "022-123456"
+    assert updated["status"] == "customer"
+    assert updated["updated_at"] >= updated["created_at"]
+
+
+def test_interactions_flow(client: TestClient):
+    customer = _create_customer(client, name="Dora")
+    customer_id = customer["id"]
+
+    response = client.post(
+        f"/customers/{customer_id}/interactions",
+        json={"interaction_type": "call", "subject": "Follow up", "notes": "Discussed pricing."},
+    )
+    assert response.status_code == 201
+    interaction = response.json()
+    assert interaction["interaction_type"] == "call"
+    assert interaction["customer_id"] == customer_id
+
+    response = client.get(f"/customers/{customer_id}/interactions")
+    assert response.status_code == 200
+    interactions = response.json()
+    assert len(interactions) == 1
+    assert interactions[0]["id"] == interaction["id"]
+
+    response = client.get("/interactions")
+    assert response.status_code == 200
+    assert any(item["id"] == interaction["id"] for item in response.json())
+
+
+def test_delete_customer(client: TestClient):
+    customer = _create_customer(client, name="Eve")
+    customer_id = customer["id"]
+
+    response = client.delete(f"/customers/{customer_id}")
+    assert response.status_code == 204
+
+    response = client.get(f"/customers/{customer_id}")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- build a FastAPI-based CRM service with customer and interaction endpoints backed by SQLite
- add database utilities, Pydantic schemas, and CRUD helpers for managing records
- document usage, dependencies, and automated tests for the API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c86602b8b08320a5a5ba44afe31e3c