### PR TITLE
Add FastAPI-based CRM system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.db
+.venv/
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,80 @@
-# test-codex
-codex測試使用
+# Simple CRM API
+
+這是一個以 FastAPI 實作的簡易客戶資料管理系統（CRM）。系統提供客戶、互動紀錄、商機與待辦任務的 CRUD 操作，以及簡單的分析摘要，可作為中小型團隊追蹤銷售流程與客戶關係的起點。
+
+## 功能特色
+
+- ✨ **客戶管理**：建立、查詢、更新、刪除客戶，並支援依狀態、標籤與關鍵字搜尋。
+- 🗒️ **互動紀錄**：記錄與客戶的電話、會議或備註，掌握歷史紀錄。
+- 💼 **商機追蹤**：針對客戶新增商機、更新狀態與金額，掌握銷售進度。
+- ✅ **待辦任務**：建立跟進任務，設定到期日與狀態，確保行動項目不遺漏。
+- 📊 **分析摘要**：取得客戶總數、Lead 數量、商機與逾期任務等概況。
+- ⚙️ **RESTful API**：採用 FastAPI，內建互動式文件（Swagger UI / ReDoc）。
+
+## 快速開始
+
+### 1. 安裝相依套件
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows 使用 .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+### 2. 啟動開發伺服器
+
+```bash
+uvicorn app.main:app --reload
+```
+
+伺服器預設會在 `http://127.0.0.1:8000` 運行，並自動建立 `crm.db` SQLite 資料庫。
+
+可透過以下網址瀏覽互動式 API 文件：
+
+- Swagger UI: <http://127.0.0.1:8000/docs>
+- ReDoc: <http://127.0.0.1:8000/redoc>
+
+### 3. 執行測試
+
+```bash
+pytest
+```
+
+測試套件會以記憶體資料庫執行，涵蓋客戶、互動、商機、任務與分析摘要的主要流程。
+
+## 主要 API
+
+| Method | Path | 描述 |
+| --- | --- | --- |
+| `GET` | `/customers` | 列出客戶並可依狀態、標籤、關鍵字過濾 |
+| `POST` | `/customers` | 新增客戶 |
+| `GET` | `/customers/{customer_id}` | 取得單一客戶（含互動、商機、任務） |
+| `PUT` | `/customers/{customer_id}` | 更新客戶資料 |
+| `DELETE` | `/customers/{customer_id}` | 刪除客戶 |
+| `GET` | `/customers/{id}/interactions` | 取得客戶互動列表 |
+| `POST` | `/customers/{id}/interactions` | 建立互動紀錄 |
+| `PUT` | `/customers/{id}/interactions/{interaction_id}` | 更新互動 |
+| `DELETE` | `/customers/{id}/interactions/{interaction_id}` | 刪除互動 |
+| `GET` | `/customers/{id}/opportunities` | 取得客戶商機列表 |
+| `POST` | `/customers/{id}/opportunities` | 建立商機 |
+| `PUT` | `/customers/{id}/opportunities/{opportunity_id}` | 更新商機 |
+| `DELETE` | `/customers/{id}/opportunities/{opportunity_id}` | 刪除商機 |
+| `GET` | `/customers/{id}/tasks` | 取得客戶任務列表 |
+| `POST` | `/customers/{id}/tasks` | 建立任務 |
+| `PUT` | `/customers/{id}/tasks/{task_id}` | 更新任務 |
+| `DELETE` | `/customers/{id}/tasks/{task_id}` | 刪除任務 |
+| `GET` | `/analytics/overview` | 取得 CRM 分析摘要 |
+
+## 設定
+
+- 預設資料庫為 `sqlite:///./crm.db`。可透過環境變數 `CRM_DATABASE_URL` 指定其他資料庫連線字串。
+- 服務啟動時會自動建立所需資料表。
+
+## 未來可延伸方向
+
+- 客製化報表與更豐富的統計資料。
+- 權限管理、使用者登入與審計紀錄。
+- 與外部服務（如電子郵件、行事曆）整合。
+- 加入前端介面或行動裝置 App。
+
+歡迎依需求調整與擴充本專案！

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,0 +1,240 @@
+"""Data access helpers for the CRM API."""
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import Sequence
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+
+
+def _tags_to_string(tags: Sequence[str] | None) -> str:
+    if not tags:
+        return ""
+    return ",".join(sorted({tag.strip() for tag in tags if tag.strip()}))
+
+
+def get_customer(db: Session, customer_id: int) -> models.Customer | None:
+    return db.get(models.Customer, customer_id)
+
+
+def get_customers(
+    db: Session,
+    *,
+    skip: int = 0,
+    limit: int = 100,
+    status: str | None = None,
+    search: str | None = None,
+    tag: str | None = None,
+) -> list[models.Customer]:
+    stmt = select(models.Customer).order_by(models.Customer.created_at.desc())
+    if status:
+        stmt = stmt.where(models.Customer.status == status)
+    if search:
+        like_term = f"%{search.lower()}%"
+        stmt = stmt.where(
+            or_(
+                func.lower(models.Customer.name).like(like_term),
+                func.lower(models.Customer.email).like(like_term),
+                func.lower(models.Customer.company).like(like_term),
+            )
+        )
+    if tag:
+        like_tag = f"%{tag.lower()}%"
+        stmt = stmt.where(func.lower(models.Customer.tags).like(like_tag))
+
+    stmt = stmt.offset(skip).limit(limit)
+    return list(db.scalars(stmt))
+
+
+def create_customer(db: Session, customer_in: schemas.CustomerCreate) -> models.Customer:
+    customer = models.Customer(
+        name=customer_in.name,
+        email=customer_in.email,
+        phone=customer_in.phone,
+        company=customer_in.company,
+        status=customer_in.status,
+        tags=_tags_to_string(customer_in.tags),
+        notes=customer_in.notes,
+    )
+    db.add(customer)
+    db.commit()
+    db.refresh(customer)
+    return customer
+
+
+def update_customer(
+    db: Session, *, customer: models.Customer, customer_in: schemas.CustomerUpdate
+) -> models.Customer:
+    update_data = customer_in.model_dump(exclude_unset=True)
+    if "tags" in update_data:
+        update_data["tags"] = _tags_to_string(update_data.get("tags"))
+    for field, value in update_data.items():
+        setattr(customer, field, value)
+    customer.updated_at = datetime.now(UTC)
+    db.add(customer)
+    db.commit()
+    db.refresh(customer)
+    return customer
+
+
+def delete_customer(db: Session, *, customer: models.Customer) -> None:
+    db.delete(customer)
+    db.commit()
+
+
+def create_interaction(
+    db: Session, *, customer: models.Customer, interaction_in: schemas.InteractionCreate
+) -> models.Interaction:
+    interaction = models.Interaction(
+        customer_id=customer.id,
+        subject=interaction_in.subject,
+        interaction_type=interaction_in.interaction_type,
+        medium=interaction_in.medium,
+        notes=interaction_in.notes,
+        occurred_at=interaction_in.occurred_at or datetime.now(UTC),
+    )
+    db.add(interaction)
+    db.commit()
+    db.refresh(interaction)
+    return interaction
+
+
+def update_interaction(
+    db: Session, *, interaction: models.Interaction, interaction_in: schemas.InteractionUpdate
+) -> models.Interaction:
+    update_data = interaction_in.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        if value is not None:
+            setattr(interaction, field, value)
+    db.add(interaction)
+    db.commit()
+    db.refresh(interaction)
+    return interaction
+
+
+def delete_interaction(db: Session, interaction: models.Interaction) -> None:
+    db.delete(interaction)
+    db.commit()
+
+
+def create_opportunity(
+    db: Session, *, customer: models.Customer, opportunity_in: schemas.OpportunityCreate
+) -> models.Opportunity:
+    opportunity = models.Opportunity(
+        customer_id=customer.id,
+        name=opportunity_in.name,
+        description=opportunity_in.description,
+        value=opportunity_in.value,
+        status=opportunity_in.status,
+        probability=opportunity_in.probability,
+        expected_close_date=opportunity_in.expected_close_date,
+    )
+    db.add(opportunity)
+    db.commit()
+    db.refresh(opportunity)
+    return opportunity
+
+
+def update_opportunity(
+    db: Session, *, opportunity: models.Opportunity, opportunity_in: schemas.OpportunityUpdate
+) -> models.Opportunity:
+    update_data = opportunity_in.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        if value is not None:
+            setattr(opportunity, field, value)
+    opportunity.updated_at = datetime.now(UTC)
+    db.add(opportunity)
+    db.commit()
+    db.refresh(opportunity)
+    return opportunity
+
+
+def delete_opportunity(db: Session, opportunity: models.Opportunity) -> None:
+    db.delete(opportunity)
+    db.commit()
+
+
+def create_task(
+    db: Session, *, customer: models.Customer, task_in: schemas.TaskCreate
+) -> models.Task:
+    task = models.Task(
+        customer_id=customer.id,
+        title=task_in.title,
+        description=task_in.description,
+        due_date=task_in.due_date,
+        status=task_in.status,
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+def update_task(db: Session, *, task: models.Task, task_in: schemas.TaskUpdate) -> models.Task:
+    update_data = task_in.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        if value is not None:
+            setattr(task, field, value)
+    task.updated_at = datetime.now(UTC)
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+def delete_task(db: Session, task: models.Task) -> None:
+    db.delete(task)
+    db.commit()
+
+
+def get_customer_summary(db: Session, customer: models.Customer) -> schemas.CustomerSummary:
+    return schemas.CustomerSummary.model_validate(customer)
+
+
+def get_analytics_snapshot(db: Session) -> schemas.AnalyticsSnapshot:
+    total_customers = db.scalar(select(func.count()).select_from(models.Customer)) or 0
+    leads = (
+        db.scalar(
+            select(func.count()).select_from(models.Customer).where(models.Customer.status == "lead")
+        )
+        or 0
+    )
+    active_opportunities = (
+        db.scalar(
+            select(func.count())
+            .select_from(models.Opportunity)
+            .where(models.Opportunity.status != "lost")
+        )
+        or 0
+    )
+    won_opportunities = (
+        db.scalar(
+            select(func.count())
+            .select_from(models.Opportunity)
+            .where(models.Opportunity.status == "won")
+        )
+        or 0
+    )
+    overdue_tasks = (
+        db.scalar(
+            select(func.count())
+            .select_from(models.Task)
+            .where(
+                models.Task.due_date.is_not(None),
+                models.Task.status != models.TaskStatus.DONE,
+                models.Task.due_date < date.today(),
+            )
+        )
+        or 0
+    )
+
+    return schemas.AnalyticsSnapshot(
+        total_customers=total_customers,
+        leads=leads,
+        active_opportunities=active_opportunities,
+        won_opportunities=won_opportunities,
+        overdue_tasks=overdue_tasks,
+    )

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,28 @@
+"""Database configuration for the CRM application."""
+from __future__ import annotations
+
+import os
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.environ.get("CRM_DATABASE_URL", "sqlite:///./crm.db")
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {},
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def get_db() -> Generator:
+    """Yield a database session for dependency injection."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,316 @@
+"""FastAPI entry-point exposing CRM functionality."""
+from __future__ import annotations
+
+from fastapi import Depends, FastAPI, HTTPException, Query, Response, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from . import crud, models, schemas
+from .database import Base, engine, get_db
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Simple CRM", version="1.0.0")
+
+
+def _get_customer_or_404(db: Session, customer_id: int) -> models.Customer:
+    customer = crud.get_customer(db, customer_id=customer_id)
+    if not customer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Customer not found")
+    return customer
+
+
+@app.get("/health", tags=["system"])
+def health_check() -> dict[str, str]:
+    """Return a simple payload used for health checking."""
+
+    return {"status": "ok"}
+
+
+@app.get(
+    "/customers",
+    response_model=list[schemas.CustomerSummary],
+    tags=["customers"],
+)
+def list_customers(
+    *,
+    db: Session = Depends(get_db),
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=50, ge=1, le=200),
+    status: str | None = Query(default=None, description="Filter customers by status"),
+    search: str | None = Query(default=None, description="Search by name, email or company"),
+    tag: str | None = Query(default=None, description="Filter customers by tag"),
+) -> list[schemas.CustomerSummary]:
+    customers = crud.get_customers(
+        db,
+        skip=skip,
+        limit=limit,
+        status=status,
+        search=search,
+        tag=tag,
+    )
+    return [schemas.CustomerSummary.model_validate(customer) for customer in customers]
+
+
+@app.post(
+    "/customers",
+    response_model=schemas.Customer,
+    status_code=status.HTTP_201_CREATED,
+    tags=["customers"],
+)
+def create_customer(
+    customer_in: schemas.CustomerCreate, *, db: Session = Depends(get_db)
+) -> schemas.Customer:
+    customer = crud.create_customer(db, customer_in=customer_in)
+    return schemas.Customer.model_validate(customer)
+
+
+@app.get(
+    "/customers/{customer_id}",
+    response_model=schemas.Customer,
+    tags=["customers"],
+)
+def get_customer(customer_id: int, *, db: Session = Depends(get_db)) -> schemas.Customer:
+    customer = _get_customer_or_404(db, customer_id)
+    return schemas.Customer.model_validate(customer)
+
+
+@app.put(
+    "/customers/{customer_id}",
+    response_model=schemas.Customer,
+    tags=["customers"],
+)
+def update_customer(
+    customer_id: int,
+    customer_in: schemas.CustomerUpdate,
+    *,
+    db: Session = Depends(get_db),
+) -> schemas.Customer:
+    customer = _get_customer_or_404(db, customer_id)
+    customer = crud.update_customer(db, customer=customer, customer_in=customer_in)
+    return schemas.Customer.model_validate(customer)
+
+
+@app.delete(
+    "/customers/{customer_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+    tags=["customers"],
+)
+def delete_customer(customer_id: int, *, db: Session = Depends(get_db)) -> Response:
+    customer = _get_customer_or_404(db, customer_id)
+    crud.delete_customer(db, customer=customer)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.get(
+    "/customers/{customer_id}/interactions",
+    response_model=list[schemas.Interaction],
+    tags=["interactions"],
+)
+def list_interactions(customer_id: int, *, db: Session = Depends(get_db)) -> list[schemas.Interaction]:
+    customer = _get_customer_or_404(db, customer_id)
+    stmt = (
+        select(models.Interaction)
+        .where(models.Interaction.customer_id == customer.id)
+        .order_by(models.Interaction.occurred_at.desc())
+    )
+    interactions = list(db.scalars(stmt))
+    return [schemas.Interaction.model_validate(interaction) for interaction in interactions]
+
+
+@app.post(
+    "/customers/{customer_id}/interactions",
+    response_model=schemas.Interaction,
+    status_code=status.HTTP_201_CREATED,
+    tags=["interactions"],
+)
+def create_interaction(
+    customer_id: int,
+    interaction_in: schemas.InteractionCreate,
+    *,
+    db: Session = Depends(get_db),
+) -> schemas.Interaction:
+    customer = _get_customer_or_404(db, customer_id)
+    interaction = crud.create_interaction(db, customer=customer, interaction_in=interaction_in)
+    return schemas.Interaction.model_validate(interaction)
+
+
+@app.put(
+    "/customers/{customer_id}/interactions/{interaction_id}",
+    response_model=schemas.Interaction,
+    tags=["interactions"],
+)
+def update_interaction(
+    customer_id: int,
+    interaction_id: int,
+    interaction_in: schemas.InteractionUpdate,
+    *,
+    db: Session = Depends(get_db),
+) -> schemas.Interaction:
+    _get_customer_or_404(db, customer_id)
+    interaction = db.get(models.Interaction, interaction_id)
+    if not interaction or interaction.customer_id != customer_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Interaction not found")
+    interaction = crud.update_interaction(db, interaction=interaction, interaction_in=interaction_in)
+    return schemas.Interaction.model_validate(interaction)
+
+
+@app.delete(
+    "/customers/{customer_id}/interactions/{interaction_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+    tags=["interactions"],
+)
+def delete_interaction(
+    customer_id: int, interaction_id: int, *, db: Session = Depends(get_db)
+) -> Response:
+    _get_customer_or_404(db, customer_id)
+    interaction = db.get(models.Interaction, interaction_id)
+    if not interaction or interaction.customer_id != customer_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Interaction not found")
+    crud.delete_interaction(db, interaction)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.get(
+    "/customers/{customer_id}/opportunities",
+    response_model=list[schemas.Opportunity],
+    tags=["opportunities"],
+)
+def list_opportunities(customer_id: int, *, db: Session = Depends(get_db)) -> list[schemas.Opportunity]:
+    customer = _get_customer_or_404(db, customer_id)
+    stmt = (
+        select(models.Opportunity)
+        .where(models.Opportunity.customer_id == customer.id)
+        .order_by(models.Opportunity.created_at.desc())
+    )
+    opportunities = list(db.scalars(stmt))
+    return [schemas.Opportunity.model_validate(opp) for opp in opportunities]
+
+
+@app.post(
+    "/customers/{customer_id}/opportunities",
+    response_model=schemas.Opportunity,
+    status_code=status.HTTP_201_CREATED,
+    tags=["opportunities"],
+)
+def create_opportunity(
+    customer_id: int,
+    opportunity_in: schemas.OpportunityCreate,
+    *,
+    db: Session = Depends(get_db),
+) -> schemas.Opportunity:
+    customer = _get_customer_or_404(db, customer_id)
+    opportunity = crud.create_opportunity(db, customer=customer, opportunity_in=opportunity_in)
+    return schemas.Opportunity.model_validate(opportunity)
+
+
+@app.put(
+    "/customers/{customer_id}/opportunities/{opportunity_id}",
+    response_model=schemas.Opportunity,
+    tags=["opportunities"],
+)
+def update_opportunity(
+    customer_id: int,
+    opportunity_id: int,
+    opportunity_in: schemas.OpportunityUpdate,
+    *,
+    db: Session = Depends(get_db),
+) -> schemas.Opportunity:
+    _get_customer_or_404(db, customer_id)
+    opportunity = db.get(models.Opportunity, opportunity_id)
+    if not opportunity or opportunity.customer_id != customer_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Opportunity not found")
+    opportunity = crud.update_opportunity(db, opportunity=opportunity, opportunity_in=opportunity_in)
+    return schemas.Opportunity.model_validate(opportunity)
+
+
+@app.delete(
+    "/customers/{customer_id}/opportunities/{opportunity_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+    tags=["opportunities"],
+)
+def delete_opportunity(
+    customer_id: int, opportunity_id: int, *, db: Session = Depends(get_db)
+) -> Response:
+    _get_customer_or_404(db, customer_id)
+    opportunity = db.get(models.Opportunity, opportunity_id)
+    if not opportunity or opportunity.customer_id != customer_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Opportunity not found")
+    crud.delete_opportunity(db, opportunity)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.get(
+    "/customers/{customer_id}/tasks",
+    response_model=list[schemas.Task],
+    tags=["tasks"],
+)
+def list_tasks(customer_id: int, *, db: Session = Depends(get_db)) -> list[schemas.Task]:
+    customer = _get_customer_or_404(db, customer_id)
+    stmt = (
+        select(models.Task)
+        .where(models.Task.customer_id == customer.id)
+        .order_by(models.Task.due_date.is_(None), models.Task.due_date.asc())
+    )
+    tasks = list(db.scalars(stmt))
+    return [schemas.Task.model_validate(task) for task in tasks]
+
+
+@app.post(
+    "/customers/{customer_id}/tasks",
+    response_model=schemas.Task,
+    status_code=status.HTTP_201_CREATED,
+    tags=["tasks"],
+)
+def create_task(
+    customer_id: int,
+    task_in: schemas.TaskCreate,
+    *,
+    db: Session = Depends(get_db),
+) -> schemas.Task:
+    customer = _get_customer_or_404(db, customer_id)
+    task = crud.create_task(db, customer=customer, task_in=task_in)
+    return schemas.Task.model_validate(task)
+
+
+@app.put(
+    "/customers/{customer_id}/tasks/{task_id}",
+    response_model=schemas.Task,
+    tags=["tasks"],
+)
+def update_task(
+    customer_id: int,
+    task_id: int,
+    task_in: schemas.TaskUpdate,
+    *,
+    db: Session = Depends(get_db),
+) -> schemas.Task:
+    _get_customer_or_404(db, customer_id)
+    task = db.get(models.Task, task_id)
+    if not task or task.customer_id != customer_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+    task = crud.update_task(db, task=task, task_in=task_in)
+    return schemas.Task.model_validate(task)
+
+
+@app.delete(
+    "/customers/{customer_id}/tasks/{task_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+    tags=["tasks"],
+)
+def delete_task(customer_id: int, task_id: int, *, db: Session = Depends(get_db)) -> Response:
+    _get_customer_or_404(db, customer_id)
+    task = db.get(models.Task, task_id)
+    if not task or task.customer_id != customer_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+    crud.delete_task(db, task)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.get("/analytics/overview", response_model=schemas.AnalyticsSnapshot, tags=["analytics"])
+def analytics_overview(*, db: Session = Depends(get_db)) -> schemas.AnalyticsSnapshot:
+    return crud.get_analytics_snapshot(db)

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,111 @@
+"""SQLAlchemy models for the CRM application."""
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from enum import Enum as PyEnum
+
+from sqlalchemy import Date, DateTime, Enum, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .database import Base
+
+
+def utcnow() -> datetime:
+    """Return a timezone-aware UTC timestamp."""
+
+    return datetime.now(UTC)
+
+
+class Customer(Base):
+    """Represents a person or organisation tracked in the CRM."""
+
+    __tablename__ = "customers"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
+    phone: Mapped[str | None] = mapped_column(String(50))
+    company: Mapped[str | None] = mapped_column(String(255))
+    status: Mapped[str] = mapped_column(String(50), default="lead", nullable=False)
+    tags: Mapped[str] = mapped_column(String(255), default="")
+    notes: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow, nullable=False
+    )
+
+    interactions: Mapped[list["Interaction"]] = relationship(
+        "Interaction", back_populates="customer", cascade="all, delete-orphan"
+    )
+    opportunities: Mapped[list["Opportunity"]] = relationship(
+        "Opportunity", back_populates="customer", cascade="all, delete-orphan"
+    )
+    tasks: Mapped[list["Task"]] = relationship(
+        "Task", back_populates="customer", cascade="all, delete-orphan"
+    )
+
+
+class Interaction(Base):
+    """Records a meeting, call or other touch point with a customer."""
+
+    __tablename__ = "interactions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    customer_id: Mapped[int] = mapped_column(ForeignKey("customers.id"), nullable=False, index=True)
+    subject: Mapped[str] = mapped_column(String(255), nullable=False)
+    interaction_type: Mapped[str] = mapped_column(String(50), default="note", nullable=False)
+    medium: Mapped[str | None] = mapped_column(String(50))
+    notes: Mapped[str | None] = mapped_column(Text)
+    occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow, nullable=False)
+
+    customer: Mapped["Customer"] = relationship("Customer", back_populates="interactions")
+
+
+class Opportunity(Base):
+    """Potential revenue opportunity linked to a customer."""
+
+    __tablename__ = "opportunities"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    customer_id: Mapped[int] = mapped_column(ForeignKey("customers.id"), nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)
+    value: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    status: Mapped[str] = mapped_column(String(50), nullable=False, default="prospecting")
+    probability: Mapped[int | None] = mapped_column(Integer)
+    expected_close_date: Mapped[date | None] = mapped_column(Date)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow, nullable=False
+    )
+
+    customer: Mapped["Customer"] = relationship("Customer", back_populates="opportunities")
+
+
+class TaskStatus(str, PyEnum):
+    """Enumeration of possible task statuses."""
+
+    TODO = "todo"
+    IN_PROGRESS = "in_progress"
+    DONE = "done"
+    BLOCKED = "blocked"
+
+
+class Task(Base):
+    """Action items that should be completed for a customer."""
+
+    __tablename__ = "tasks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    customer_id: Mapped[int] = mapped_column(ForeignKey("customers.id"), nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)
+    due_date: Mapped[date | None] = mapped_column(Date)
+    status: Mapped[TaskStatus] = mapped_column(Enum(TaskStatus), default=TaskStatus.TODO, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow, nullable=False
+    )
+
+    customer: Mapped["Customer"] = relationship("Customer", back_populates="tasks")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,167 @@
+"""Pydantic schemas for the CRM API."""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from .models import TaskStatus
+
+
+class InteractionBase(BaseModel):
+    subject: str
+    interaction_type: str = Field(default="note", max_length=50)
+    medium: Optional[str] = Field(default=None, max_length=50)
+    notes: Optional[str] = None
+    occurred_at: Optional[datetime] = None
+
+
+class InteractionCreate(InteractionBase):
+    pass
+
+
+class InteractionUpdate(BaseModel):
+    subject: Optional[str] = None
+    interaction_type: Optional[str] = Field(default=None, max_length=50)
+    medium: Optional[str] = Field(default=None, max_length=50)
+    notes: Optional[str] = None
+    occurred_at: Optional[datetime] = None
+
+
+class Interaction(InteractionBase):
+    id: int
+    customer_id: int
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OpportunityBase(BaseModel):
+    name: str
+    description: Optional[str] = None
+    value: float = 0.0
+    status: str = Field(default="prospecting", max_length=50)
+    probability: Optional[int] = Field(default=None, ge=0, le=100)
+    expected_close_date: Optional[date] = None
+
+
+class OpportunityCreate(OpportunityBase):
+    pass
+
+
+class OpportunityUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    value: Optional[float] = None
+    status: Optional[str] = Field(default=None, max_length=50)
+    probability: Optional[int] = Field(default=None, ge=0, le=100)
+    expected_close_date: Optional[date] = None
+
+
+class Opportunity(OpportunityBase):
+    id: int
+    customer_id: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TaskBase(BaseModel):
+    title: str
+    description: Optional[str] = None
+    due_date: Optional[date] = None
+    status: TaskStatus = TaskStatus.TODO
+
+
+class TaskCreate(TaskBase):
+    pass
+
+
+class TaskUpdate(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    due_date: Optional[date] = None
+    status: Optional[TaskStatus] = None
+
+
+class Task(TaskBase):
+    id: int
+    customer_id: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CustomerBase(BaseModel):
+    name: str
+    email: str
+    phone: Optional[str] = None
+    company: Optional[str] = None
+    status: str = Field(default="lead", max_length=50)
+    tags: List[str] = Field(default_factory=list)
+    notes: Optional[str] = None
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def parse_tags(cls, value: object) -> List[str]:
+        if value is None or value == "":
+            return []
+        if isinstance(value, str):
+            return [tag.strip() for tag in value.split(",") if tag.strip()]
+        return list(value)
+
+
+class CustomerCreate(CustomerBase):
+    pass
+
+
+class CustomerUpdate(BaseModel):
+    name: Optional[str] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    company: Optional[str] = None
+    status: Optional[str] = Field(default=None, max_length=50)
+    tags: Optional[List[str]] = None
+    notes: Optional[str] = None
+
+
+class Customer(CustomerBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+    interactions: List[Interaction] = Field(default_factory=list)
+    opportunities: List[Opportunity] = Field(default_factory=list)
+    tasks: List[Task] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CustomerSummary(BaseModel):
+    id: int
+    name: str
+    email: str
+    status: str
+    company: Optional[str]
+    tags: List[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def parse_tags(cls, value: object) -> List[str]:
+        if value is None or value == "":
+            return []
+        if isinstance(value, str):
+            return [tag.strip() for tag in value.split(",") if tag.strip()]
+        return list(value)
+
+
+class AnalyticsSnapshot(BaseModel):
+    total_customers: int
+    leads: int
+    active_opportunities: int
+    won_opportunities: int
+    overdue_tasks: int

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.110.0
+uvicorn==0.27.1
+sqlalchemy==2.0.25
+pydantic==2.6.3
+pydantic-settings==2.1.0
+pytest==8.0.2
+httpx==0.27.0

--- a/tests/test_crm_api.py
+++ b/tests/test_crm_api.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.database import Base, get_db
+from app.main import app
+
+TEST_DATABASE_URL = "sqlite+pysqlite:///:memory:"
+
+engine = create_engine(
+    TEST_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+
+
+@pytest.fixture
+def client() -> TestClient:
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_create_and_retrieve_customer(client: TestClient) -> None:
+    payload = {
+        "name": "Alice Example",
+        "email": "alice@example.com",
+        "phone": "123456789",
+        "company": "Example Corp",
+        "status": "lead",
+        "tags": ["vip", "newsletter"],
+        "notes": "Important new lead.",
+    }
+    response = client.post("/customers", json=payload)
+    assert response.status_code == 201
+    created = response.json()
+    assert created["id"] > 0
+    assert created["name"] == payload["name"]
+    assert set(created["tags"]) == {"newsletter", "vip"}
+
+    response = client.get(f"/customers/{created['id']}")
+    assert response.status_code == 200
+    fetched = response.json()
+    assert fetched["email"] == payload["email"]
+    assert fetched["notes"] == payload["notes"]
+
+
+def test_list_customers_with_filters(client: TestClient) -> None:
+    customer_one = {
+        "name": "Bob Builder",
+        "email": "bob@example.com",
+        "status": "prospect",
+        "company": "BuildIt",
+        "tags": ["contractor"],
+    }
+    customer_two = {
+        "name": "Charlie Consultant",
+        "email": "charlie@example.com",
+        "status": "lead",
+        "company": "Advisors Inc",
+        "tags": ["vip"],
+    }
+    for payload in (customer_one, customer_two):
+        assert client.post("/customers", json=payload).status_code == 201
+
+    response = client.get("/customers")
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+    response = client.get("/customers", params={"status": "lead"})
+    assert response.status_code == 200
+    results = response.json()
+    assert len(results) == 1
+    assert results[0]["email"] == "charlie@example.com"
+
+    response = client.get("/customers", params={"search": "build"})
+    assert response.status_code == 200
+    results = response.json()
+    assert len(results) == 1
+    assert results[0]["email"] == "bob@example.com"
+
+    response = client.get("/customers", params={"tag": "vip"})
+    assert response.status_code == 200
+    results = response.json()
+    assert len(results) == 1
+    assert results[0]["email"] == "charlie@example.com"
+
+
+def test_interactions_workflow(client: TestClient) -> None:
+    customer = client.post(
+        "/customers",
+        json={"name": "Dana", "email": "dana@example.com", "status": "lead"},
+    ).json()
+    customer_id = customer["id"]
+
+    create_response = client.post(
+        f"/customers/{customer_id}/interactions",
+        json={
+            "subject": "Intro Call",
+            "interaction_type": "call",
+            "medium": "phone",
+            "notes": "Discussed project scope",
+        },
+    )
+    assert create_response.status_code == 201
+    interaction = create_response.json()
+    assert interaction["subject"] == "Intro Call"
+
+    update_response = client.put(
+        f"/customers/{customer_id}/interactions/{interaction['id']}",
+        json={"notes": "Call went well"},
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["notes"] == "Call went well"
+
+    list_response = client.get(f"/customers/{customer_id}/interactions")
+    assert list_response.status_code == 200
+    assert len(list_response.json()) == 1
+
+    delete_response = client.delete(
+        f"/customers/{customer_id}/interactions/{interaction['id']}"
+    )
+    assert delete_response.status_code == 204
+    assert client.get(f"/customers/{customer_id}/interactions").json() == []
+
+
+def test_opportunities_tasks_and_analytics(client: TestClient) -> None:
+    today = date.today()
+    customer = client.post(
+        "/customers",
+        json={"name": "Eve", "email": "eve@example.com", "status": "prospect"},
+    ).json()
+    customer_id = customer["id"]
+
+    opportunity_response = client.post(
+        f"/customers/{customer_id}/opportunities",
+        json={
+            "name": "New Project",
+            "value": 5000.0,
+            "status": "proposal",
+            "probability": 60,
+        },
+    )
+    assert opportunity_response.status_code == 201
+    opportunity = opportunity_response.json()
+
+    update_opportunity = client.put(
+        f"/customers/{customer_id}/opportunities/{opportunity['id']}",
+        json={"status": "won"},
+    )
+    assert update_opportunity.status_code == 200
+    assert update_opportunity.json()["status"] == "won"
+
+    task_future = client.post(
+        f"/customers/{customer_id}/tasks",
+        json={
+            "title": "Send contract",
+            "due_date": (today + timedelta(days=3)).isoformat(),
+            "status": "in_progress",
+        },
+    ).json()
+    assert task_future["status"] == "in_progress"
+
+    task_overdue_response = client.post(
+        f"/customers/{customer_id}/tasks",
+        json={
+            "title": "Follow-up email",
+            "due_date": (today - timedelta(days=1)).isoformat(),
+            "status": "todo",
+        },
+    )
+    assert task_overdue_response.status_code == 201
+
+    update_task = client.put(
+        f"/customers/{customer_id}/tasks/{task_future['id']}",
+        json={"status": "done"},
+    )
+    assert update_task.status_code == 200
+    assert update_task.json()["status"] == "done"
+
+    # Add a second customer to ensure analytics counts leads correctly
+    client.post(
+        "/customers",
+        json={"name": "Frank", "email": "frank@example.com", "status": "lead"},
+    )
+
+    analytics = client.get("/analytics/overview").json()
+    assert analytics["total_customers"] == 2
+    assert analytics["leads"] == 1
+    assert analytics["active_opportunities"] == 1
+    assert analytics["won_opportunities"] == 1
+    assert analytics["overdue_tasks"] == 1
+
+    # Clean up by deleting a task and verifying removal
+    overdue_task_id = task_overdue_response.json()["id"]
+    delete_task_resp = client.delete(f"/customers/{customer_id}/tasks/{overdue_task_id}")
+    assert delete_task_resp.status_code == 204
+    tasks_remaining = client.get(f"/customers/{customer_id}/tasks").json()
+    assert len(tasks_remaining) == 1
+    assert tasks_remaining[0]["id"] == task_future["id"]


### PR DESCRIPTION
## Summary
- implement a FastAPI application that exposes customer, interaction, opportunity and task management endpoints plus analytics
- add SQLAlchemy models, CRUD helpers, and Pydantic schemas with timezone-aware timestamps and tag handling
- document usage, add dependencies, gitignore, and provide pytest coverage for key CRM flows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c86602b8b08320a5a5ba44afe31e3c